### PR TITLE
Use babel-node to run webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-ts/src": "tsc --project ./src --noEmit",
     "check-ts/root": "tsc --project ./ --noEmit",
     "check-ts": "run-p 'check-ts/*'",
-    "build": "NODE_ENV=production webpack",
+    "build": "NODE_ENV=production babel-node ./node_modules/.bin/webpack",
     "deploy": "babel-node deploy.js",
     "clean": "del-cli ./dist build.zip",
     "lint": "run-p -l --aggregate-output lint-ts lint-js check-ts",


### PR DESCRIPTION
This command is not run in PRs, but it caused the regular push build to fail.