### PR TITLE
Fix Max-Age on Set-Cookie header

### DIFF
--- a/src/setHeadersOnOriginResponse.ts
+++ b/src/setHeadersOnOriginResponse.ts
@@ -51,7 +51,7 @@ export const createSetHeadersOnOriginResponse = ({
   const envCookie =
     !branch && env
       ? cookie.serialize('env', env, {
-          maxAge: 24 * 60 * 60 * 1000,
+          maxAge: 24 * 60 * 60,
           httpOnly: true,
           secure: true,
           sameSite: 'lax',
@@ -62,7 +62,7 @@ export const createSetHeadersOnOriginResponse = ({
 
   const branchCookie = branch
     ? cookie.serialize('branch', branch, {
-        maxAge: 2 * 60 * 60 * 1000,
+        maxAge: 2 * 60 * 60,
         httpOnly: true,
         secure: true,
         sameSite: 'lax',


### PR DESCRIPTION
The `maxAge` value is in seconds, not milliseconds.

Fixes hollowverse/hollowverse#559